### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -29,5 +29,5 @@
   },
   "tui": { "enabled": false },
   "sync": { "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"] },
-  "nxCloudId": "68a51c2de2f455e1bda99040"
+  "nxCloudId": "68a52db5f8990856bf6a011c"
 }

--- a/nx.json
+++ b/nx.json
@@ -1,10 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "targetDefaults": {
-    "build": {
-      "cache": true
-    }
-  },
+  "targetDefaults": { "build": { "cache": true } },
   "namedInputs": {
     "sources": ["{projectRoot}/package.json", "{projectRoot}/**/*.ts"]
   },
@@ -12,9 +8,7 @@
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -31,16 +25,9 @@
       "conventionalCommits": true,
       "preVersionCommand": "pnpm nx run-many -t build"
     },
-    "changelog": {
-      "projectChangelogs": {
-        "createRelease": "github"
-      }
-    }
+    "changelog": { "projectChangelogs": { "createRelease": "github" } }
   },
-  "tui": {
-    "enabled": false
-  },
-  "sync": {
-    "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"]
-  }
+  "tui": { "enabled": false },
+  "sync": { "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"] },
+  "nxCloudId": "68a511cdb51b57372b7d08c5"
 }

--- a/nx.json
+++ b/nx.json
@@ -29,5 +29,5 @@
   },
   "tui": { "enabled": false },
   "sync": { "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"] },
-  "nxCloudId": "68a511cdb51b57372b7d08c5"
+  "nxCloudId": "68a51c2de2f455e1bda99040"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/60c0dfeae9a52f000559b563/workspaces/68a51c2de2f455e1bda99040

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.